### PR TITLE
Fix find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     keywords='pulp_certguard',
     name='pulp_certguard',
-    packages=find_packages(include=['pulp_certguard']),
+    packages=find_packages(exclude=['tests']),
     setup_requires=setup_requirements,
     test_suite='tests',
     tests_require=test_requirements,


### PR DESCRIPTION
Find_packages should exclude tests folder but include all the others.

It  was failing with `no module names pulp_certguard.app`

Without including all the other packages it was installing only `pulp_certguard/` but missing `pup_certguard/app` package and then failing when installing without the `-e`


Closes #4521
https://pulp.plan.io/issues/4521