### PR TITLE
Update the pulpcore-plugin to rc1 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 requirements = [
-    'pulpcore-plugin>=0.1.0b7',
+    'pulpcore-plugin~=0.1rc1',
     'PyOpenSSL',
 ]
 
@@ -12,7 +12,7 @@ with open('README.rst') as f:
 
 setup(
     name='pulp-certguard',
-    version='0.1.0',
+    version='0.1.0rc1',
     description='X.509 Certguards plugin for the Pulp Project',
     long_description=long_description,
     license='GPLv2+',


### PR DESCRIPTION
The docs were already updated, so all that needed fixing was the
dependency string and the version bump to 0.1.0rc1 for pulp-certguard.

https://pulp.plan.io/issues/4601
closes #4601