### PR TITLE
Updates to use x509 in url and TYPE

### DIFF
--- a/pulp_certguard/app/models.py
+++ b/pulp_certguard/app/models.py
@@ -123,7 +123,7 @@ class Validator:
 
     @property
     def store(self):
-        """A X509 certificate (trust) store.
+        """A X.509 certificate (trust) store.
 
         Returns:
             openssl.X509Store: A store containing the CA certificate.

--- a/pulp_certguard/app/serializers.py
+++ b/pulp_certguard/app/serializers.py
@@ -28,7 +28,7 @@ class CertGuardSerializer(ContentGuardSerializer):
         try:
             Validator.load(buffer.decode('utf8'))
         except ValueError:
-            reason = _('Must be PEM encoded x.509 certificate.')
+            reason = _('Must be PEM encoded X.509 certificate.')
             raise serializers.ValidationError(reason)
         else:
             return certificate

--- a/pulp_certguard/app/viewsets.py
+++ b/pulp_certguard/app/viewsets.py
@@ -7,7 +7,7 @@ from .serializers import CertGuardSerializer
 class CertGuardViewSet(ContentGuardViewSet):
     """CertGuard API Viewsets."""
 
-    endpoint_name = 'certguard'
+    endpoint_name = 'x509'
     queryset = CertGuard.objects.all()
     serializer_class = CertGuardSerializer
     filterset_class = ContentGuardFilter

--- a/pulp_certguard/tests/functional/api/test_certguard.py
+++ b/pulp_certguard/tests/functional/api/test_certguard.py
@@ -16,7 +16,7 @@ from pulp_smash.pulp3.utils import (
 from pulp_certguard.tests.functional.constants import (
     CERT_CA_FILE_PATH,
     CERT_CLIENT_FILE_PATH,
-    CONTENT_GUARDS_PATH,
+    X509_CONTENT_GUARD_PATH,
     FILE_REMOTE_PATH,
     FILE_PUBLISHER_PATH
 )
@@ -55,7 +55,7 @@ class CertGuardTestCase(unittest.TestCase):
             # 1. Create certguard
             with open(CERT_CA_FILE_PATH, 'rb') as cert_ca_file:
                 cls.certguard = client.post(
-                    CONTENT_GUARDS_PATH,
+                    X509_CONTENT_GUARD_PATH,
                     data={'name': utils.uuid4()},
                     files={'ca_certificate': cert_ca_file}
                 )

--- a/pulp_certguard/tests/functional/constants.py
+++ b/pulp_certguard/tests/functional/constants.py
@@ -1,6 +1,8 @@
 """Constants for Pulp certguard plugin tests."""
 import os
-from pulp_smash.pulp3.constants import BASE_PATH, CONTENT_GUARDS_PATH  # noqa:F401
+from urllib.parse import urljoin
+
+from pulp_smash.pulp3.constants import BASE_PATH, BASE_CONTENT_GUARDS_PATH  # noqa:F401
 from pulp_file.tests.functional.constants import FILE_REMOTE_PATH, FILE_PUBLISHER_PATH  # noqa:F401
 
 _CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -10,3 +12,4 @@ CERTS_BASE_PATH = os.path.join(
 CERT_CA_FILE_PATH = os.path.join(CERTS_BASE_PATH, 'ca.pem')
 CERT_CLIENT_FILE_PATH = os.path.join(CERTS_BASE_PATH, 'client.pem')
 KEYS_BASE_PATH = os.path.join(_CURRENT_DIR, 'x509', 'keys')
+X509_CONTENT_GUARD_PATH = urljoin(BASE_CONTENT_GUARDS_PATH, "certguard/x509/")


### PR DESCRIPTION
The name being x509 makes more sense than certguard.

https://pulp.plan.io/issues/4593
closes #4593