### PR TITLE
Updates x509 certguard URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 ``pulp_certguard`` Plugin
 =========================
 
-This is the ``pulp_certguard`` Plugin for `Pulp Project
-3.0+ <https://pypi.org/project/pulpcore/>`__. This plugin provides X.509 certificate based
-content protection. The `CertGuard` authenticates the web request by validating the client
-certificate passed in the ``SSL_CLIENT_CERTIFICATE`` HTTP header using the CA (Certificate Authority)
-certificate that it has been configured with.
+This is the ``pulp_certguard`` Plugin for the
+`Pulp Project 3.0+ <https://pypi.org/project/pulpcore/>`__. This plugin provides X.509 certificate
+based content protection. The `X509CertGuard` authenticates the web request by validating the client
+certificate passed in the ``SSL_CLIENT_CERTIFICATE`` HTTP header using the CA (Certificate
+Authority) certificate that it has been configured with.
 
 All REST API examples bellow use `httpie <https://httpie.org/doc>`__ to perform the requests.
 The ``httpie`` commands below assume that the user executing the commands has a ``.netrc`` file
@@ -60,8 +60,8 @@ Make and Run Migrations
 
 .. code-block:: bash
 
-   pulp-manager makemigrations certguard
-   pulp-manager migrate certguard
+   django-admin makemigrations certguard
+   django-admin migrate certguard
 
 
 Create a content guard named ``foo``
@@ -69,17 +69,17 @@ Create a content guard named ``foo``
 
 This example assumes that ``~/ca.pem`` is a PEM encoded CA certificate.
 
-``$ http --form POST http://localhost:8000/pulp/api/v3/contentguards/certguard/certguard/ name=foo ca_certificate@~/ca.pem``
+``$ http --form POST http://localhost:8000/pulp/api/v3/contentguards/certguard/x509/ name=foo ca_certificate@~/ca.pem``
 
 .. code:: json
 
    {
        ...
-       "_href": "/pulp/api/v3/contentguards/certguard/1/",
+       "_href": "/pulp/api/v3/contentguards/certguard/x509/3046291f-d432-4a85-9d7e-fad12b0aaed7/",
        ...
    }
 
-``$ export GUARD_HREF=$(http localhost:8000/pulp/api/v3/contentguards/certguard/certguard/?name=foo | jq -r '.results[0]._href')``
+``$ export GUARD_HREF=$(http localhost:8000/pulp/api/v3/contentguards/certguard/x509/?name=foo | jq -r '.results[0]._href')``
 
 
 Create a distribution with content protection
@@ -91,7 +91,7 @@ Create a distribution with content protection
 
    {
        ...
-       "_href": "/pulp/api/v3/distributions/1/"
+       "_href": "/pulp/api/v3/distributions/305adfe0-4851-432f-9de3-13f9b10fe131/"
        ...
    }
 
@@ -105,7 +105,7 @@ Add content protection to an existing distribution
 
    {
        ...
-       "_href": "/pulp/api/v3/distributions/1/"
+       "_href": "/pulp/api/v3/distributions/0fbb102a-cb38-4d5c-afc2-b9a76e862a1d/"
        ...
    }
 

--- a/pulp_certguard/app/models.py
+++ b/pulp_certguard/app/models.py
@@ -12,16 +12,16 @@ from pulpcore.plugin.models import ContentGuard
 log = getLogger(__name__)
 
 
-class CertGuard(ContentGuard):
+class X509CertGuard(ContentGuard):
     """
-    An X.509 certificate based content-guard.
+    A content-guard that authenticates the request based on a client provided X.509 Certificate.
 
     Fields:
         ca_certificate (models.FileField): The CA certificate used to
             validate the client certificate.
     """
 
-    TYPE = 'certguard'
+    TYPE = 'x509'
 
     def _certpath(self, name):
         return storage.get_tls_path(self, name)
@@ -123,7 +123,7 @@ class Validator:
 
     @property
     def store(self):
-        """A X509 certificate (trust) store.
+        """A X.509 certificate (trust) store.
 
         Returns:
             openssl.X509Store: A store containing the CA certificate.

--- a/pulp_certguard/app/serializers.py
+++ b/pulp_certguard/app/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 
 from pulpcore.plugin.serializers import ContentGuardSerializer
 
-from .models import CertGuard, Validator
+from .models import X509CertGuard, Validator
 
 
 class CertGuardSerializer(ContentGuardSerializer):
@@ -16,7 +16,7 @@ class CertGuardSerializer(ContentGuardSerializer):
     )
 
     class Meta:
-        model = CertGuard
+        model = X509CertGuard
         fields = ContentGuardSerializer.Meta.fields + (
             'ca_certificate',
         )
@@ -28,7 +28,7 @@ class CertGuardSerializer(ContentGuardSerializer):
         try:
             Validator.load(buffer.decode('utf8'))
         except ValueError:
-            reason = _('Must be PEM encoded x.509 certificate.')
+            reason = _('Must be PEM encoded X.509 certificate.')
             raise serializers.ValidationError(reason)
         else:
             return certificate

--- a/pulp_certguard/app/viewsets.py
+++ b/pulp_certguard/app/viewsets.py
@@ -1,13 +1,13 @@
 from pulpcore.plugin.viewsets import ContentGuardFilter, ContentGuardViewSet
 
-from .models import CertGuard
+from .models import X509CertGuard
 from .serializers import CertGuardSerializer
 
 
 class CertGuardViewSet(ContentGuardViewSet):
-    """CertGuard API Viewsets."""
+    """X509CertGuard API Viewsets."""
 
-    endpoint_name = 'certguard'
-    queryset = CertGuard.objects.all()
+    endpoint_name = 'x509'
+    queryset = X509CertGuard.objects.all()
     serializer_class = CertGuardSerializer
     filterset_class = ContentGuardFilter

--- a/pulp_certguard/tests/functional/api/test_certguard.py
+++ b/pulp_certguard/tests/functional/api/test_certguard.py
@@ -16,7 +16,7 @@ from pulp_smash.pulp3.utils import (
 from pulp_certguard.tests.functional.constants import (
     CERT_CA_FILE_PATH,
     CERT_CLIENT_FILE_PATH,
-    CONTENT_GUARDS_PATH,
+    X509_CONTENT_GUARD_PATH,
     FILE_REMOTE_PATH,
     FILE_PUBLISHER_PATH
 )
@@ -55,7 +55,7 @@ class CertGuardTestCase(unittest.TestCase):
             # 1. Create certguard
             with open(CERT_CA_FILE_PATH, 'rb') as cert_ca_file:
                 cls.certguard = client.post(
-                    CONTENT_GUARDS_PATH,
+                    X509_CONTENT_GUARD_PATH,
                     data={'name': utils.uuid4()},
                     files={'ca_certificate': cert_ca_file}
                 )

--- a/pulp_certguard/tests/functional/constants.py
+++ b/pulp_certguard/tests/functional/constants.py
@@ -1,6 +1,8 @@
 """Constants for Pulp certguard plugin tests."""
 import os
-from pulp_smash.pulp3.constants import BASE_PATH, CONTENT_GUARDS_PATH  # noqa:F401
+from urllib.parse import urljoin
+
+from pulp_smash.pulp3.constants import BASE_PATH, BASE_CONTENT_GUARDS_PATH  # noqa:F401
 from pulp_file.tests.functional.constants import FILE_REMOTE_PATH, FILE_PUBLISHER_PATH  # noqa:F401
 
 _CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -10,3 +12,4 @@ CERTS_BASE_PATH = os.path.join(
 CERT_CA_FILE_PATH = os.path.join(CERTS_BASE_PATH, 'ca.pem')
 CERT_CLIENT_FILE_PATH = os.path.join(CERTS_BASE_PATH, 'client.pem')
 KEYS_BASE_PATH = os.path.join(_CURRENT_DIR, 'x509', 'keys')
+X509_CONTENT_GUARD_PATH = urljoin(BASE_CONTENT_GUARDS_PATH, "certguard/x509/")


### PR DESCRIPTION
The name being x509 makes more sense than certguard.

https://pulp.plan.io/issues/4593
closes #4593