### PR TITLE
Include test files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+recursive-include pulp_certguard/tests/functional/artifacts *


### PR DESCRIPTION
add test files as certificate and scripts used
with test to MANIFEST.in as when installed without
pip editable option 'pip install -e' it is not
packaged

re: #4245
https://pulp.plan.io/issues/4245

Signed-off-by: Pavel Picka <ppicka@redhat.com>