### PR TITLE
Add new changelog process

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,0 +1,14 @@
+=======
+Credits
+=======
+
+Development Lead
+----------------
+
+* Pulp Certguard Team <pulp-list@redhat.com>
+
+Contributors
+------------
+
+Brian Bouterse
+Jeff Ortel

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,15 @@
+=========
+Changelog
+=========
+
+..
+    You should *NOT* be adding new change log entries to this file, this
+    file is managed by towncrier. You *may* edit previous change logs to
+    fix problems like typo corrections or such.
+    To add a new change log entry, please see
+    https://docs.pulpproject.org/en/3.0/nightly/contributing/git.html#changelog-update
+
+    WARNING: Don't drop the next directive!
+
+.. towncrier release notes start
+

--- a/CHANGES/.TEMPLATE.rst
+++ b/CHANGES/.TEMPLATE.rst
@@ -1,0 +1,36 @@
+{% for section, _ in sections.items() %}
+{% set underline = underlines[0] %}{% if section %}{{section}}
+{{ underline * section|length }}{% set underline = underlines[1] %}
+
+{% endif %}
+
+{% if sections[section] %}
+{% for category, val in definitions.items() if category in sections[section]%}
+{{ definitions[category]['name'] }}
+{{ underline * definitions[category]['name']|length }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category].items() %}
+- {{ text }}
+  {{ values|join(',\n  ') }}
+{% endfor %}
+
+{% else %}
+- {{ sections[section][category]['']|join(', ') }}
+
+{% endif %}
+{% if sections[section][category]|length == 0 %}
+No significant changes.
+
+{% else %}
+{% endif %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}
+{% endfor %}
+----
+

--- a/CHANGES/.gitignore
+++ b/CHANGES/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/CHANGES/4875.doc
+++ b/CHANGES/4875.doc
@@ -1,0 +1,1 @@
+Switch to using `towncrier <https://github.com/hawkowl/towncrier>`_ for better release notes.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,162 @@
+============
+Contributing
+============
+
+Contributions are welcome, and they are greatly appreciated! Every little bit
+helps, and credit will always be given.
+
+You can contribute in many ways:
+
+
+Types of Contributions
+----------------------
+
+
+Report Bugs
+~~~~~~~~~~~
+
+Report bugs at https://pulp.plan.io/projects/certguard/issues/new.
+
+If you are reporting a bug, please include:
+
+* Your operating system name and version.
+* Any details about your local setup that might be helpful in troubleshooting.
+* Detailed steps to reproduce the bug.
+
+
+Fix Bugs
+~~~~~~~~
+
+Look through the Redmine open issues:  https://tinyurl.com/y6mjcpvm
+
+
+Implement Features
+~~~~~~~~~~~~~~~~~~
+
+Look through the Redmine Stories for features:  https://tinyurl.com/y35w3wxu
+
+
+Write Documentation
+~~~~~~~~~~~~~~~~~~~
+
+pulp-certguard could always use more documentation, whether as part of the
+official pulp-certguard docs, in docstrings, or even on the web in blog posts,
+articles, and such.
+
+
+Submit Feedback
+~~~~~~~~~~~~~~~
+
+The best way to send feedback is to file an issue at https://pulp.plan.io/projects/certguard/issues/new.
+
+If you are proposing a feature:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that contributions
+  are welcome :)
+
+
+Get Started!
+------------
+
+Ready to contribute? Here's how to set up `pulp_certguard` for local development.
+
+1. Fork the `pulp_certguard` repo on GitHub.
+2. Clone your fork locally::
+
+    $ git clone git@github.com:your_name_here/pulp_certguard.git
+
+3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
+
+    $ mkvirtualenv pulp_certguard
+    $ cd pulp_certguard/
+    $ python setup.py develop
+
+4. Create a branch for local development::
+
+    $ git checkout -b name-of-your-bugfix-or-feature
+
+   Now you can make your changes locally.
+
+5. When you're done making changes, add a :ref:`changelog update <changelog-update>`.
+
+6. Check that your changes pass flake8 and the tests, including testing other Python versions with
+   tox::
+
+    $ flake8 pulp_certguard tests
+    $ python setup.py test or py.test
+    $ tox
+
+   To get flake8 and tox, just pip install them into your virtualenv.
+
+6. Commit your changes and push your branch to GitHub::
+
+    $ git add .
+    $ git commit -m "Your detailed description of your changes."
+    $ git push origin name-of-your-bugfix-or-feature
+
+7. Submit a pull request through the GitHub website.
+
+
+Pull Request Guidelines
+-----------------------
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1. The pull request should include tests.
+
+2. If the pull request adds functionality, the docs should be updated. Put
+   your new functionality into a function with a docstring, and add a
+   :ref:`changelog update <changelog-update>`
+
+3. The pull request should work for Python 3.6 and 3.6 and both PostgreSQL and MaridDB.
+
+
+.. _changelog-update:
+
+Changelog update
+****************
+
+The CHANGES.rst file is managed using the `towncrier tool <https://github.com/hawkowl/towncrier>`_
+and all non trivial changes must be accompanied by a news entry.
+
+To add an entry to the news file, you first need an issue in pulp.plan.io describing the change you
+want to make. Once you have an issue, take its number and create a file inside of the ``CHANGES/``
+directory named after that issue number with an extension of .feature, .bugfix, .doc, .removal, or
+.misc. So if your issue is 3543 and it fixes a bug, you would create the file
+``CHANGES/3543.bugfix``.
+
+PRs can span multiple categories by creating multiple files (for instance, if you added a feature
+and deprecated an old feature at the same time, you would create CHANGES/NNNN.feature and
+CHANGES/NNNN.removal). Likewise if a PR touches multiple issues/PRs you may create a file for each
+of them with the exact same contents and Towncrier will deduplicate them.
+
+The contents of this file are reStructuredText formatted text that will be used as the content of
+the news file entry. You do not need to reference the issue or PR numbers here as towncrier will
+automatically add a reference to all of the affected issues when rendering the news file.
+
+
+Tips
+----
+
+To run a subset of tests::
+
+$ py.test tests.test_pulp_certguard
+
+
+Deploying
+---------
+
+A reminder for the maintainers on how to deploy.
+
+Use the ``towncrier`` command to generate the ``CHANGES.rst``. At release time this can be moved to
+``HISTORY.rst``.
+
+Then run::
+
+$ bumpversion patch # possible: major / minor / patch
+$ git push
+$ git push --tags
+
+Travis will then deploy to PyPI if tests pass.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,0 +1,4 @@
+0.1.0rc1
+========
+
+Initial release!

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+towncrier

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,0 +1,5 @@
+.. _pulp-certguard-changes:
+
+.. include:: ../CHANGES.rst
+
+.. include:: ../HISTORY.rst

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,1 +1,0 @@
-.. include:: ../HISTORY.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 Welcome to pulp-certguard's documentation!
-======================================
+==========================================
 
 .. toctree::
    :maxdepth: 2
@@ -8,11 +8,10 @@ Welcome to pulp-certguard's documentation!
    readme
    installation
    usage
-   modules
    contributing
    authors
-   history
    yum-howto
+   changes
 
 Indices and tables
 ==================

--- a/pulp_certguard/__init__.py
+++ b/pulp_certguard/__init__.py
@@ -1,1 +1,5 @@
+import pkg_resources
+
+__version__ = pkg_resources.get_distribution("pulp-certguard").version
+
 default_app_config = 'pulp_certguard.app.PulpCertGuardPluginAppConfig'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.towncrier]
+package = "pulp_certguard"
+filename = "CHANGES.rst"
+directory = "CHANGES/"
+title_format = "{version} ({project_date})"
+template = "CHANGES/.TEMPLATE.rst"
+issue_format = "`#{issue} <https://pulp.plan.io/issues/{issue}>`_"


### PR DESCRIPTION
- Fix broken sphinx docs site
- Adds a changelog update section to the docs
- creates the base CHANGES.rst file
- creates the CHANGES directory for news updates and indicates to git to
  store the dir even if empty with a .gitignore.
- adds a release note for this change
- adds a docs section that loads the CHANGES.rst file on the website

https://pulp.plan.io/issues/4875
re #4875