### PR TITLE
Explicitly specify version in __version__

### DIFF
--- a/pulp_certguard/__init__.py
+++ b/pulp_certguard/__init__.py
@@ -1,5 +1,3 @@
-import pkg_resources
-
-__version__ = pkg_resources.get_distribution("pulp-certguard").version
+__version__ = '0.1.0rc1'
 
 default_app_config = 'pulp_certguard.app.PulpCertGuardPluginAppConfig'


### PR DESCRIPTION
Since RTD doesn't actually install pulp-certguard it can't use this type
of lookup. I'm hardcoding the version now, and we can use bumpversion
later to auto-manage this.

https://pulp.plan.io/issues/4875
re #4875