### PR TITLE
Change heading of changelog docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -116,7 +116,7 @@ Before you submit a pull request, check that it meets these guidelines:
 .. _changelog-update:
 
 Changelog update
-****************
+----------------
 
 The CHANGES.rst file is managed using the `towncrier tool <https://github.com/hawkowl/towncrier>`_
 and all non trivial changes must be accompanied by a news entry.


### PR DESCRIPTION
This heading wasn't being clearly shown.

https://pulp.plan.io/issues/4875
re #4875