### PR TITLE
Pulpcore version bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 requirements = [
     'PyOpenSSL',
-    'pulpcore>=3.0.0rc8,<3.1',
+    'pulpcore>=3.0.0rc8,<3.2',
 ]
 
 with open('README.rst') as f:


### PR DESCRIPTION
Raise the maximum version of pulpcore to <3.2

Required PR: https://github.com/pulp/pulp_file/pull/319
Required PR: https://github.com/pulp/pulpcore/pull/395

[noissue]