### PR TITLE
Update pulpcore requirement to fix Travis builds

### DIFF
--- a/CHANGES/6105.misc
+++ b/CHANGES/6105.misc
@@ -1,0 +1,1 @@
+Bumping pulpcore requirement to fix pulpcore Travis builds.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 requirements = [
     'PyOpenSSL',
-    'pulpcore>=3.0.0rc8,<3.2',
+    'pulpcore>=3.0,<3.3',
 ]
 
 with open('README.rst') as f:


### PR DESCRIPTION
pulp-certguard is forcing our CI to install pulpcore 3.1 even though pulpcore master is at 3.2.

fixes #6105