### PR TITLE
Renames internals to clearly indicate X509 type

### DIFF
--- a/CHANGES/6296.misc
+++ b/CHANGES/6296.misc
@@ -1,0 +1,1 @@
+Renames all X509 related objects in the code to have X509 as their object name prefix.

--- a/pulp_certguard/app/models.py
+++ b/pulp_certguard/app/models.py
@@ -39,14 +39,14 @@ class X509CertGuard(ContentGuard):
 
         """
         ca = self.ca_certificate.read()
-        validator = Validator(ca.decode('utf8'))
+        validator = X509Validator(ca.decode('utf8'))
         validator(request)
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
 
 
-class Validator:
+class X509Validator:
     """An X.509 certificate validator."""
 
     SSL_CERTIFICATE_HEADER = 'SSL-CLIENT-CERTIFICATE'
@@ -88,7 +88,7 @@ class Validator:
 
         """
         try:
-            return openssl.load_certificate(openssl.FILETYPE_PEM, buffer=Validator.format(pem))
+            return openssl.load_certificate(openssl.FILETYPE_PEM, buffer=X509Validator.format(pem))
         except Exception as le:
             raise ValueError(str(le))
 
@@ -113,7 +113,7 @@ class Validator:
             reason = _('HTTP header "{h}" not found.').format(h=name)
             raise KeyError(reason)
         else:
-            return Validator.load(certificate)
+            return X509Validator.load(certificate)
 
     def __init__(self, ca_certificate):
         """Inits a new validator.

--- a/pulp_certguard/app/serializers.py
+++ b/pulp_certguard/app/serializers.py
@@ -4,14 +4,14 @@ from rest_framework import serializers
 
 from pulpcore.plugin.serializers import ContentGuardSerializer
 
-from .models import X509CertGuard, Validator
+from .models import X509CertGuard, X509Validator
 
 
-class CertGuardSerializer(ContentGuardSerializer):
-    """Content Guard Serializer."""
+class X509CertGuardSerializer(ContentGuardSerializer):
+    """X.509 Content Guard Serializer."""
 
     ca_certificate = serializers.FileField(
-        help_text="The Certificate Authority (CA) certificate.",
+        help_text=_("The Certificate Authority certificate."),
         write_only=True
     )
 
@@ -26,9 +26,9 @@ class CertGuardSerializer(ContentGuardSerializer):
         """Validates the given certificate."""
         buffer = certificate.read()
         try:
-            Validator.load(buffer.decode('utf8'))
+            X509Validator.load(buffer.decode('utf8'))
         except ValueError:
-            reason = _('Must be PEM encoded X.509 certificate.')
+            reason = _("Must be PEM encoded X.509 certificate.")
             raise serializers.ValidationError(reason)
         else:
             return certificate

--- a/pulp_certguard/app/viewsets.py
+++ b/pulp_certguard/app/viewsets.py
@@ -1,13 +1,13 @@
 from pulpcore.plugin.viewsets import ContentGuardFilter, ContentGuardViewSet
 
 from .models import X509CertGuard
-from .serializers import CertGuardSerializer
+from .serializers import X509CertGuardSerializer
 
 
-class CertGuardViewSet(ContentGuardViewSet):
+class X509CertGuardViewSet(ContentGuardViewSet):
     """X509CertGuard API Viewsets."""
 
     endpoint_name = 'x509'
     queryset = X509CertGuard.objects.all()
-    serializer_class = CertGuardSerializer
+    serializer_class = X509CertGuardSerializer
     filterset_class = ContentGuardFilter

--- a/pulp_certguard/tests/functional/constants.py
+++ b/pulp_certguard/tests/functional/constants.py
@@ -10,10 +10,11 @@ from pulp_file.tests.functional.constants import (  # noqa:F401
 )
 
 _CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
-CERTS_BASE_PATH = os.path.join(
+
+X509_CERTS_BASE_PATH = os.path.join(
     _CURRENT_DIR, 'artifacts', 'x509', 'certificates'
 )
-CERT_CA_FILE_PATH = os.path.join(CERTS_BASE_PATH, 'ca.pem')
-CERT_CLIENT_FILE_PATH = os.path.join(CERTS_BASE_PATH, 'client.pem')
-KEYS_BASE_PATH = os.path.join(_CURRENT_DIR, 'x509', 'keys')
+X509_CERT_CA_FILE_PATH = os.path.join(X509_CERTS_BASE_PATH, 'ca.pem')
+X509_CERT_CLIENT_FILE_PATH = os.path.join(X509_CERTS_BASE_PATH, 'client.pem')
+X509_KEYS_BASE_PATH = os.path.join(_CURRENT_DIR, 'x509', 'keys')
 X509_CONTENT_GUARD_PATH = urljoin(BASE_CONTENT_GUARDS_PATH, "certguard/x509/")


### PR DESCRIPTION
Renames all X509 related objects in the code to have X509 as their
object name prefix.

* Renamed Validator -> X509Validator
* CertGuardSerializer -> X509CertGuardSerializer
* CertGuardViewSet -> X509CertGuardViewSet
* various pulp_certguard.tests.functional.constants
* CertGuardTestCase -> X509CertGuardTestCase
* Various docstrings and variable names

https://pulp.plan.io/issues/6296
closes #6296