### PR TITLE
Rename SSL-CLIENT-CERTIFICATE to X-CLIENT-CERT

### DIFF
--- a/CHANGES/4891.removal
+++ b/CHANGES/4891.removal
@@ -1,0 +1,1 @@
+Renames the ``SSL_CLIENT_CERTIFICATE`` to be ``X-CLIENT-CERT``.

--- a/contrib/yum/certguard.py
+++ b/contrib/yum/certguard.py
@@ -13,7 +13,7 @@ from yum.plugins import TYPE_CORE
 requires_api_version = '2.3'
 plugin_type = (TYPE_CORE,)
 
-ID_SSL_HEADER = "SSL-CLIENT-CERTIFICATE"
+ID_SSL_HEADER = "X-CLIENT-CERT"
 CERT_PATH = "/etc/boomi/yum.pem"
 # Repos that begin with this prefix will be handled by this plugin
 REPO_PREFIX = "boomi-"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Welcome to pulp-certguard's documentation!
 This is the ``pulp_certguard`` Plugin for the `Pulp Project 3.0+ <https://pypi.org/project/
 pulpcore/>`__. This plugin provides X.509 certificate based content protection. The `X509CertGuard`
 authenticates the web request by validating the client certificate passed in the
-``SSL_CLIENT_CERTIFICATE`` HTTP header using the CA (Certificate Authority) certificate that it has
+``X-CLIENT-CERT`` HTTP header using the CA (Certificate Authority) certificate that it has
 been configured with.
 
 .. toctree::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -72,10 +72,10 @@ And, a PEM encoded private key at ``~/key.pem``.
 
 
 Example of GET directly to the content application running on port 24816 over HTTP. When setting the
-``SSL-CLIENT-CERTIFICATE`` manually, the newlines need to be stripped due to restrictions
+``X-CLIENT-CERT`` manually, the newlines need to be stripped due to restrictions
 on legal characters in HTTP header values.
 
-``$ http localhost:24816/pulp/content/files/1.iso SSL-CLIENT-CERTIFICATE:"$(tr -d '\n' < ~/client.pem)"``
+``$ http localhost:24816/pulp/content/files/1.iso X-CLIENT-CERT:"$(tr -d '\n' < ~/client.pem)"``
 
 .. code-block::
 
@@ -85,8 +85,8 @@ on legal characters in HTTP header values.
 
 
 Example of GET through a reverse proxy using HTTPS (like apache or nginx) in front of the content
-application. It's assumed that the reverse proxy has been configured to set the SSL-CLIENT-CERTIFICATE
-header using the client certificate exchanged as part of the SSL negotiation.
+application. It's assumed that the reverse proxy has been configured to set the
+``X-CLIENT-CERT`` header using the client certificate exchanged as part of the SSL negotiation.
 
 ``$ http https://localhost/pulp/content/files/1.iso --cert=~/client.pem --cert-key=~/key.pem --verify=no``
 

--- a/pulp_certguard/app/models.py
+++ b/pulp_certguard/app/models.py
@@ -49,7 +49,7 @@ class X509CertGuard(ContentGuard):
 class X509Validator:
     """An X.509 certificate validator."""
 
-    SSL_CERTIFICATE_HEADER = 'SSL-CLIENT-CERTIFICATE'
+    CERT_HEADER_NAME = 'X-CLIENT-CERT'
 
     @staticmethod
     def format(pem):
@@ -93,7 +93,7 @@ class X509Validator:
             raise ValueError(str(le))
 
     def client_certificate(self, request):
-        """Extract and load the client certificate passed in the SSL-CLIENT-CERTIFICATE header.
+        """Extract and load the client certificate passed in the X-CLIENT-CERT header.
 
         Args:
             request (aiohttp.web.Request): A request for a published file.
@@ -106,7 +106,7 @@ class X509Validator:
                 been passed in the request.
 
         """
-        name = self.SSL_CERTIFICATE_HEADER
+        name = self.CERT_HEADER_NAME
         try:
             certificate = request.headers[name]
         except KeyError:

--- a/pulp_certguard/tests/functional/api/test_certguard.py
+++ b/pulp_certguard/tests/functional/api/test_certguard.py
@@ -100,7 +100,7 @@ class X509CertGuardTestCase(unittest.TestCase):
         # Pick a filename
         unit_path = choice(get_file_content_paths(self.repo))
 
-        # Try to download it without the SSL-CLIENT-CERTIFICATE
+        # Try to download it without the X-CLIENT-CERT header set
         with self.assertRaises(HTTPError):
             download_content_unit(self.cfg, distribution, unit_path)
 
@@ -124,12 +124,12 @@ class X509CertGuardTestCase(unittest.TestCase):
         # Pick a filename
         unit_path = choice(get_file_content_paths(self.repo))
 
-        # Try to download it passing the proper SSL-CLIENT-CERTIFICATE
+        # Try to download it passing the proper X-CLIENT-CERT
         download_content_unit(
             self.cfg,
             distribution,
             unit_path,
-            headers={'SSL-CLIENT-CERTIFICATE': self.client_cert}
+            headers={'X-CLIENT-CERT': self.client_cert}
         )
 
     def test_positive_add_x509_certguard_to_existing_distribution(self):
@@ -165,12 +165,12 @@ class X509CertGuardTestCase(unittest.TestCase):
         with self.assertRaises(HTTPError):
             download_content_unit(self.cfg, distribution, unit_path)
 
-        # Try to download it passing the proper SSL-CLIENT-CERTIFICATE
+        # Try to download it passing the proper X-CLIENT-CERT
         download_content_unit(
             self.cfg,
             distribution,
             unit_path,
-            headers={'SSL-CLIENT-CERTIFICATE': self.client_cert}
+            headers={'X-CLIENT-CERT': self.client_cert}
         )
 
     def test_positive_remove_contentguard(self):
@@ -195,7 +195,7 @@ class X509CertGuardTestCase(unittest.TestCase):
         # Pick a filename
         unit_path = choice(get_file_content_paths(self.repo))
 
-        # Try to download it without the SSL-CLIENT-CERTIFICATE
+        # Try to download it without the X-CLIENT-CERT
         with self.assertRaises(HTTPError):
             download_content_unit(self.cfg, distribution, unit_path)
 


### PR DESCRIPTION
This adds a backwards incompatible release note along with updates to
the code, tests, and docs.

https://pulp.plan.io/issues/4891
closes #4891