### PR TITLE
Problem: plugin-template is out-of-date

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -84,12 +84,13 @@ fi
 
 git clone --depth=1 https://github.com/pulp/pulpcore.git --branch master
 
+cd pulpcore
 if [ -n "$PULP_PR_NUMBER" ]; then
-  cd pulpcore
   git fetch --depth=1 origin pull/$PULP_PR_NUMBER/head:$PULP_PR_NUMBER
   git checkout $PULP_PR_NUMBER
-  cd ..
 fi
+
+cd ..
 
 
 

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -31,15 +31,14 @@ else
     sed "s/localhost/$(hostname)/g" ../pulpcore/.travis/pulp-smash-config.json > ~/.config/pulp_smash/settings.json
 fi
 
-
-
-if [[ "$TEST" == 'pulp' || "$TEST" == 'performance' ]]; then
+if [[ "$TEST" == 'pulp' || "$TEST" == 'performance' || "$TEST" == 's3' ]]; then
     # Many tests require pytest/mock, but users do not need them at runtime
     # (or to add plugins on top of pulpcore or pulp container images.)
     # So install it here, rather than in the image Dockerfile.
     $CMD_PREFIX pip3 install pytest mock
     # Many functional tests require these
     $CMD_PREFIX dnf install -yq lsof which dnf-plugins-core
+    
 fi
 
 if [[ -f $POST_BEFORE_SCRIPT ]]; then

--- a/.travis/cherrypick.py
+++ b/.travis/cherrypick.py
@@ -67,7 +67,7 @@ repo.git.checkout(STABLE_BRANCH)
 g = Github(GITHUB_TOKEN)
 grepo = g.get_repo(REPOSITORY)
 (label,) = (l for l in grepo.get_labels() if l.name == PR_LABEL)
-issues = grepo.get_issues(labels=[label], state="all")
+issues = grepo.get_issues(labels=[label], state="all", sort="updated", direction="asc")
 
 cherrypicks = []
 
@@ -91,9 +91,9 @@ for issue in issues:
         if ret.returncode != 0:
             print(f"Failed to cherry-pick commit {commit.sha}: {ret.stderr.decode('ascii')}")
             exit(1)
-        else:
-            cherrypicks.append(issue)
-            print(f"Cherry-picked commit {commit.sha}.")
+
+    cherrypicks.append(issue)
+    print(f"Cherry-picked commit {commit.sha}.")
 
 # check if we cherry picked anything
 if len(cherrypicks) == 0:
@@ -115,7 +115,7 @@ print(f"Created pull request {pr.html_url}.")
 for cp in cherrypicks:
     labels = cp.labels
     labels.remove(label)
-    cp.edit(labels=labels)
+    cp.edit(labels=[l.name for l in labels])
     print(f"Removed label '{PR_LABEL}' from PR #{cp.number}.")
 
 print("Cherry picking complete.")

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -58,7 +58,7 @@ if [ "$TEST" = 'bindings' ]; then
 
   rm -rf ./pulpcore-client
 
-  ./generate.sh pulpcore ruby
+  ./generate.sh pulpcore ruby 0
   cd pulpcore-client
   gem build pulpcore_client
   gem install --both ./pulpcore_client-0.gem
@@ -66,7 +66,7 @@ if [ "$TEST" = 'bindings' ]; then
 
   rm -rf ./pulp_certguard-client
 
-  ./generate.sh pulp_certguard ruby
+  ./generate.sh pulp_certguard ruby 0
 
   cd pulp_certguard-client
   gem build pulp_certguard_client
@@ -89,6 +89,13 @@ export CMD_STDIN_PREFIX="sudo kubectl exec -i $PULP_API_POD --"
 cat unittest_requirements.txt | $CMD_STDIN_PREFIX bash -c "cat > /tmp/test_requirements.txt"
 $CMD_PREFIX pip3 install -r /tmp/test_requirements.txt
 
+if [[ "$TEST" == 's3' ]]; then
+  mc config host add s3 http://localhost:9000 AKIAIT2Z5TDYPX3ARJBA fqRvjWaPU5o0fCqQuUWbj9Fainj2pVZtBCiDiieS --api S3v4
+  mc config host rm local
+  mc mb s3/pulp3 --region eu-central-1
+  mc tree s3
+fi
+
 # Run unit tests.
 $CMD_PREFIX bash -c "PULP_DATABASES__default__USER=postgres django-admin test --noinput /usr/local/lib/python${TRAVIS_PYTHON_VERSION}/site-packages/pulp_certguard/tests/unit/"
 
@@ -107,11 +114,12 @@ export PYTHONPATH=$TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR/../pulpcore:${PYTHONPATH}
 set -u
 
 if [[ "$TEST" == "performance" ]]; then
+  wget -qO- https://github.com/crazy-max/travis-wait-enhanced/releases/download/v1.0.0/travis-wait-enhanced_1.0.0_linux_x86_64.tar.gz | sudo tar -C /usr/local/bin -zxvf - travis-wait-enhanced
   echo "--- Performance Tests ---"
   if [[ -z ${PERFORMANCE_TEST+x} ]]; then
-    pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_certguard.tests.performance || show_logs_and_return_non_zero
+    travis-wait-enhanced --interval=1m --timeout=40m -- pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_certguard.tests.performance || show_logs_and_return_non_zero
   else
-    pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_certguard.tests.performance.test_$PERFORMANCE_TEST || show_logs_and_return_non_zero
+    travis-wait-enhanced --interval=1m --timeout=40m -- pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_certguard.tests.performance.test_$PERFORMANCE_TEST || show_logs_and_return_non_zero
   fi
   exit
 fi

--- a/template_config.yml
+++ b/template_config.yml
@@ -2,7 +2,8 @@
 # were not present before running plugin-template have been added with their default values.
 
 additional_plugins:
-- { name: pulp_file, branch: master }
+- branch: master
+  name: pulp_file
 black: false
 check_commit_message: true
 cherry_pick_automation: false
@@ -25,10 +26,13 @@ plugin_name: pulp-certguard
 plugin_snake: pulp_certguard
 pulp_settings: null
 pulpcore_branch: master
+pulpcore_pip_version_specifier: null
 pydocstyle: true
 pypi_username: pulp
 stable_branch: null
 test_bindings: true
 test_performance: false
+test_s3: false
+travis_addtl_services: []
 travis_notifications: null
 


### PR DESCRIPTION
Solution: Regenerate with latest template

[noissue]

re: #6422
Plugins cannot modify the CI pulp-content containers easily because there are 2 of them
https://pulp.plan.io/issues/6422

re: #4664
As a user, I can use a RHSMCertGuard
https://pulp.plan.io/issues/4664