### PR TITLE
Adds debugging docs page and fixes TOC

### DIFF
--- a/CHANGES/6744.doc
+++ b/CHANGES/6744.doc
@@ -1,0 +1,1 @@
+Adds debugging documentation on how users can enable, use, and interpret the debugging logging.

--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -1,0 +1,43 @@
+Debugging
+=========
+
+``pulp-certguard`` contains debug statements which show the raw, received value of the
+``X-CLIENT-CERT`` header. This can be very valuable when debugging where the problem is in the chain
+of certificates from the::
+
+    client <--> reverse proxy <--> pulp-certguard
+
+Enabling Debugging
+------------------
+
+Debugging is most easily enabled by adding the following line to your settings file, which is
+by default located at ``/etc/pulp/settings.py``::
+
+    LOGGING = {"dynaconf_merge": True, "loggers": {'': {'handlers': ['console'], 'level': 'DEBUG'}}}
+
+After restarting your server-side services and making a request that sets the ``X-CLIENT-CERT``
+header, you should see a log message for each request where pulp-certguard is receiving a
+``X-CLIENT-CERT`` header.
+
+Using Logging Info
+------------------
+
+If you make a request but do not see a log message, you could have one of the following problems:
+
+1. Debug logging is not enabled or applied. Check your ``LOGGING`` config.
+
+2. The client is not requesting content from a Distribution protected with ``pulp-certguard``. Check
+   your ``Distribution`` configuration.
+
+3. The reverse proxy isn't configured to pass along the ``X-CLIENT-CERT`` config correctly. Check
+   your reverse proxy config against the example configs documented on this site.
+
+
+If you do see a log message, but it's still not working you could have one of the following
+problems:
+
+1. The client isn't submitting the client certificate correctly to the reverse proxy. Ensure the
+   client is submitting a certificate and key via TLS to the reverse proxy.
+
+2. The reverse proxy configuration is not correct. Compare your reverse proxy config against the
+   example configs documented on this site.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,8 +28,9 @@ date of June 30, 2023. Company Foo also does the following:
    reverse_proxy_config
    usage
    rest_api
-   contributing
+   debugging
    yum-howto
+   contributing
    changes
 
 Indices and tables

--- a/docs/yum-howto.rst
+++ b/docs/yum-howto.rst
@@ -2,17 +2,15 @@
    :format: html
 
 
-Table of Contents
-=================
-   #. `easy_rsa setup <#org81f9613>`_
-   #. `pulp setup <#orgced9f17>`_
-   #. `certguard setup <#orgdb8c46e>`_
-   #. `yum setup <#org06aad41>`_
+#. `easy_rsa setup <#org81f9613>`_
+#. `pulp setup <#orgced9f17>`_
+#. `certguard setup <#orgdb8c46e>`_
+#. `yum setup <#org06aad41>`_
 
 :raw-html-m2r:`<a id="org806629e"></a>`
 
-Used easy_rsa v3
-==============================================
+Configure yum/dnf
+=================
 
 When doing this, I used the following as a guide. These are
 essentially all you need to end up with a protected rpm repo.
@@ -26,10 +24,11 @@ https://github.com/pulp/pulp-certguard
 
 https://github.com/OpenVPN/easy-rsa/blob/master/README.quickstart.md
 
+
 :raw-html-m2r:`<a id="org81f9613"></a>`
 
 easy_rsa setup
---------------------------------------------
+--------------
 
 Once you get the easy_rsa rpm installed, copy the skeleton of scripts to where you want your cert infra to live.
 The quickstart guide is easy to follow.
@@ -63,7 +62,6 @@ I have a habit of keeping everything in a local git repo, just so i can do rever
    ./easyrsa sign-req client yum-client
    # now convert it to pem format
    openssl x509 -in pki/issued/yum-client.crt  -out pki/issued/yum-client.pem -outform PEM
-
 
 
 :raw-html-m2r:`<a id="orgced9f17"></a>`
@@ -128,7 +126,6 @@ didn't immediately know to check there and wasted some time.
    http GET  http://localhost:24816/pulp/content/boomi-epel-2/repodata/repomd.xml
 
 
-
 :raw-html-m2r:`<a id="orgdb8c46e"></a>`
 
 certguard setup
@@ -153,7 +150,6 @@ troubleshoot it til it does. Then we can add protection.
 
    # protect one
    http PATCH http://localhost:24817/pulp/api/v3/distributions/rpm/rpm/4d9ef794-4af1-44ba-be5e-607defd396de/ content_guard=$GUARD_HREF
-
 
 
 :raw-html-m2r:`<a id="org06aad41"></a>`


### PR DESCRIPTION
A new debugging section is added, which outlines how users can enable,
use, and interpret the debugging logging build into pulp-certguard.

Also the yum/dnf section was renamed and its page-level table of
contents title removed which was cascading to the homepage
unecessarily.

https://pulp.plan.io/issues/6744
closes #6744