### PR TITLE
Problem: If you install functest_requirements.txt, pulp-file always

### DIFF
--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash
-git+https://github.com/pulp/pulp_file.git
 pulpcore-client
+pulp-file
 pulp-file-client
 pytest


### PR DESCRIPTION
gets upgraded to the master branch.

Solution: Specify pulp-file with no version specifier.

Leaves currently installed version intact. Defalts to current
stable release.

[noissue]