### PR TITLE
Making pulp-certguard compatible with pulpcore 3.5

### DIFF
--- a/CHANGES/7177.bugfix
+++ b/CHANGES/7177.bugfix
@@ -1,0 +1,1 @@
+Making pulp-certguard compatible with pulpcore 3.5


### PR DESCRIPTION
https://pulp.plan.io/issues/7175
closes #7177