### PR TITLE
Fix rest API documentation link in docs

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -4,4 +4,4 @@ REST API
 Pulp Certguard Endpoints
 ------------------------
 
-Pulp Cert Guard API Reference `pulp-certguard REST documentation <redoc_ui.html>`_
+Pulp Cert Guard API Reference `pulp-certguard REST documentation <../restapi.html>`_


### PR DESCRIPTION
Seems like the new restapi.html should be used instead of the redoc_ui.html