### PR TITLE
Add gitleaks config to skip test-data.

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+[allowlist]
+  files = [
+    'pulp_certguard/tests/functional/artifacts/rhsm/v3/5527980418107729172-key.pem',
+    'pulp_certguard/tests/functional/artifacts/x509/keys/server.pem',
+    'pulp_certguard/tests/functional/artifacts/rhsm/v3/4260035510644027985-key.pem',
+    'pulp_certguard/tests/functional/artifacts/x509/keys/client.pem',
+    'pulp_certguard/tests/functional/artifacts/x509/keys/ca.pem',
+    'pulp_certguard/tests/functional/artifacts/rhsm/v1/159442575569388840-key.pem',
+    'pulp_certguard/tests/functional/artifacts/rhsm/v1/1514454871848760713-key.pem',
+    'pulp_certguard/tests/functional/artifacts/rhsm/untrusted_cert-key.pem',
+    'pulp_certguard/tests/functional/artifacts/rhsm/uber.cert',
+    'pulp_certguard/tests/functional/artifacts/rhsm/katello-default-ca.key',
+    'pulp_certguard/tests/functional/artifacts/thirdparty_ca/keys/ca.pem'
+  ]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,4 +29,5 @@ ignore = [
     ".pep8speaks.yml",
     ".ci/**",
     ".github/**",
+    ".gitleaks.toml",
 ]


### PR DESCRIPTION
Gitleaks checks repos for potentially-leaked secrets. We have a
number of things that would be sensitive data, except they're
just test-keys that don't actually expose anything. This config
adds all such existing files to the allowlist to avoid false
positives.

See https://github.com/zricethezav/gitleaks for more info.

[noissue]