### PR TITLE
Specify upper bound on PyOpenSSL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyOpenSSL
+PyOpenSSL<23.0
 pulpcore>=3.10,<3.25


### PR DESCRIPTION
The current latest release is 22.0.0, and from their changelog it seems
they use semver, so I'm assuming all 22.y.z release are safe.

[noissue]