### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyOpenSSL<23.0
+PyOpenSSL<22.1
 pulpcore>=3.10,<3.25


### PR DESCRIPTION
Use a more stringent upper version constraint on PyOpenSSL to ensure that cryptography can be installed at <38.0.0. Only required as a temporary fix while pulpcore has a dependency on cryptography~=37.0.4

Follows issue here https://github.com/pulp/pulpcore/issues/3269.