### PR TITLE
Add requests to functest_requirements

### DIFF
--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -2,6 +2,7 @@ pulpcore-client
 pulp-file-client
 pulp-certguard-client
 pytest
+requests
 
 # for pulp_file tests
 git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash


### PR DESCRIPTION
This was an oversight at the test rewrite, but is happend that the library was already installed in all ci environments.

[noissue]