### PR TITLE
Allow pyOpenSSL<24 to pick up fixes in 23.0.

### DIFF
--- a/CHANGES/293.bugfix
+++ b/CHANGES/293.bugfix
@@ -1,0 +1,1 @@
+Loosened restriction on pyOpenSSL to let us use 23.0 and its fixes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyOpenSSL<23.0
+PyOpenSSL<24.0
 pulpcore>=3.23.0,<3.40


### PR DESCRIPTION
fixes #293.