### PR TITLE
Bumped compatibility for pulpcore 3.44

### DIFF
--- a/CHANGES/+pulpcore_3.40.feature
+++ b/CHANGES/+pulpcore_3.40.feature
@@ -1,0 +1,1 @@
+Declared pulpcore compatibility up to 3.44.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 PyOpenSSL<24.0
-pulpcore>=3.28.0,<3.40
+pulpcore>=3.28.0,<3.45


### PR DESCRIPTION
This is intentionally not bumping to 3.54 right now, so we have the chance to merge the codebase of this plugin with pulpcore in 3.45.

[noissue]

(cherry picked from commit 76be83777a964e9e92adbddfe90ef74b6fce079b)