### PR TITLE
Move special ci dependencies in the proper place

### DIFF
--- a/ci_requirements.txt
+++ b/ci_requirements.txt
@@ -1,1 +1,3 @@
+python-dateutil
+rhsm
 pulp_file>=0.14.0


### PR DESCRIPTION
Make use of ci_requirements.txt to install python-dateutil and rhsm. There is no good reason to add an extra codepath to the plugin-template for this.

[noissue]