### PR TITLE
Move special ci dependencies in the proper place

### DIFF
--- a/ci_requirements.txt
+++ b/ci_requirements.txt
@@ -1,1 +1,3 @@
+python-dateutil
+rhsm
 pulp_file<1.15


### PR DESCRIPTION
Make use of ci_requirements.txt to install python-dateutil and rhsm. There is no good reason to add an extra codepath to the plugin-template for this.

[noissue]

(cherry picked from commit a0028564b26c97fccb741b24f188ac2743a7c119)